### PR TITLE
Allow the Jekyll site to be run locally with Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # IDE files
 .idea
 .env
+_site
+.jekyll-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:2.6
+
+ENV LC_ALL C.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+WORKDIR /usr/src/app
+
+COPY Gemfile start-here-hyperledger.gemspec ./
+RUN gem install bundler && bundle install
+
+EXPOSE 4000

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gemspec
+
+gem "jekyll-remote-theme"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,86 @@
+PATH
+  remote: .
+  specs:
+    just-the-docs (0.3.3)
+      jekyll (>= 3.8.5)
+      jekyll-seo-tag (~> 2.0)
+      rake (>= 12.3.1, < 13.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.1.9)
+    em-websocket (0.5.2)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    eventmachine (1.2.7)
+    ffi (1.15.3)
+    forwardable-extended (2.6.0)
+    http_parser.rb (0.6.0)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.2.0)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (~> 2.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.4.0)
+      pathutil (~> 0.9)
+      rouge (~> 3.0)
+      safe_yaml (~> 1.0)
+      terminal-table (~> 2.0)
+    jekyll-remote-theme (0.4.3)
+      addressable (~> 2.0)
+      jekyll (>= 3.5, < 5.0)
+      jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
+      rubyzip (>= 1.3.0, < 3.0)
+    jekyll-sass-converter (2.1.0)
+      sassc (> 2.0.1, < 3.0)
+    jekyll-seo-tag (2.7.1)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    kramdown (2.3.1)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.3)
+    listen (3.5.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (4.0.6)
+    rake (13.0.3)
+    rb-fsevent (0.11.0)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    rexml (3.2.5)
+    rouge (3.26.0)
+    rubyzip (2.3.0)
+    safe_yaml (1.0.5)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    terminal-table (2.0.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
+    unicode-display_width (1.7.0)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  bundler (~> 2.2.21)
+  jekyll-remote-theme
+  just-the-docs!
+
+BUNDLED WITH
+   2.2.21

--- a/_config.yml
+++ b/_config.yml
@@ -23,3 +23,4 @@ gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into t
 exclude: ["hyperledger-updates", "templates", "actions", "docker"]
 plugins:
   - jekyll-remote-theme
+  

--- a/_config.yml
+++ b/_config.yml
@@ -21,3 +21,5 @@ gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into t
 
 # List of excludes from being built into the website
 exclude: ["hyperledger-updates", "templates", "actions", "docker"]
+plugins:
+  - jekyll-remote-theme

--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,6 @@ gh_edit_branch: "main" # the branch that your docs is served from
 gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
 
 # List of excludes from being built into the website
-exclude: ["hyperledger-updates", "templates", "actions", "docker"]
+exclude: ["hyperledger-updates", "templates", "actions", "docker", "start-here-hyperledger.gemspec", "Dockerfile"]
 plugins:
   - jekyll-remote-theme
-  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.5"
+
+services:
+  jekyll:
+    build:
+      context: ./
+    ports:
+      - 4000:4000
+    volumes:
+      - .:/usr/src/app
+    stdin_open: true
+    tty: true
+    command: bundle exec jekyll serve -H 0.0.0.0 -t

--- a/start-here-hyperledger.gemspec
+++ b/start-here-hyperledger.gemspec
@@ -4,8 +4,8 @@
 Gem::Specification.new do |spec|
   spec.name          = "just-the-docs"
   spec.version       = "0.3.3"
-  spec.authors       = ["Patrick Marsceill"]
-  spec.email         = ["patrick.marsceill@gmail.com"]
+  spec.authors       = [""]
+  spec.email         = [""]
 
   spec.summary       = %q{A modern, highly customizable, and responsive Jekyll theme for documention with built-in search.}
   spec.homepage      = "https://github.com/pmarsceill/just-the-docs"

--- a/start-here-hyperledger.gemspec
+++ b/start-here-hyperledger.gemspec
@@ -1,0 +1,22 @@
+
+# coding: utf-8
+
+Gem::Specification.new do |spec|
+  spec.name          = "just-the-docs"
+  spec.version       = "0.3.3"
+  spec.authors       = ["Patrick Marsceill"]
+  spec.email         = ["patrick.marsceill@gmail.com"]
+
+  spec.summary       = %q{A modern, highly customizable, and responsive Jekyll theme for documention with built-in search.}
+  spec.homepage      = "https://github.com/pmarsceill/just-the-docs"
+  spec.license       = "MIT"
+
+  spec.files         = `git ls-files -z`.split("\x0").select { |f| f.match(%r{^(assets|bin|_layouts|_includes|lib|Rakefile|_sass|LICENSE|README)}i) }
+  spec.executables   << 'just-the-docs'
+
+  spec.add_development_dependency "bundler", "~> 2.2.21"
+  spec.add_runtime_dependency "jekyll", ">= 3.8.5"
+  spec.add_runtime_dependency "jekyll-seo-tag", "~> 2.0"
+  spec.add_runtime_dependency "rake", ">= 12.3.1", "< 13.1.0"
+
+end


### PR DESCRIPTION
Added docker related configuration to allow the site to be run locally using Docker. Changes are made in the `_config.yaml` to ensure all dependencies are met so that the remote theme could be resolved locally. 

