### PR TITLE
Add all contributors for Hyperledger GitHub orgs

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -14,7 +14,7 @@ jobs:
         uses: "actions/checkout@v2"
         with:
           submodules: recursive
-      - name: Get contributors information
+      - name: Get hyperledger-updates contributors information
         uses: "hyperledger-tooling/github-contributors-action@main"
         env:
           GITHUB_AUTH_TOKEN: "${{ secrets.PAT }}"
@@ -31,6 +31,32 @@ jobs:
           CONTRIBUTORS_SECTION_PATTERN: "## GitHub Action Contributors"
           INPUT_TEMPLATE_FILE: ./templates/contributor-template.md
           FILE_WITH_PATTERN: ./index.md
+      - name: Get Hyperledger contributors information
+        uses: "hyperledger-tooling/github-contributors-action@main"
+        env:
+          GITHUB_AUTH_TOKEN: "${{ secrets.PAT }}"
+          SOURCE_GITHUB_REPOSITORY: hyperledger
+          CONTRIBUTORS_SECTION_PATTERN: "## Hyperledger GitHub Contributors"
+          CONTRIBUTORS_SECTION_END_PATTERN: "## Hyperledger Labs GitHub Contributors"
+          INPUT_TEMPLATE_FILE: ./templates/contributor-template.md
+          FILE_WITH_PATTERN: ./community.md
+      - name: Get Hyperledger Labs contributors information
+        uses: "hyperledger-tooling/github-contributors-action@main"
+        env:
+          GITHUB_AUTH_TOKEN: "${{ secrets.PAT }}"
+          SOURCE_GITHUB_REPOSITORY: hyperledger-labs
+          CONTRIBUTORS_SECTION_PATTERN: "## Hyperledger Labs GitHub Contributors"
+          CONTRIBUTORS_SECTION_END_PATTERN: "## Hyperledger Tooling GitHub Contributors"
+          INPUT_TEMPLATE_FILE: ./templates/contributor-template.md
+          FILE_WITH_PATTERN: ./community.md
+      - name: Get Hyperledger Tooling contributors information
+        uses: "hyperledger-tooling/github-contributors-action@main"
+        env:
+          GITHUB_AUTH_TOKEN: "${{ secrets.PAT }}"
+          SOURCE_GITHUB_REPOSITORY: hyperledger-tooling
+          CONTRIBUTORS_SECTION_PATTERN: "## Hyperledger Tooling GitHub Contributors"
+          INPUT_TEMPLATE_FILE: ./templates/contributor-template.md
+          FILE_WITH_PATTERN: ./community.md
       - name: Create Pull Request with new backend contributors
         uses: peter-evans/create-pull-request@v3
         with:

--- a/community.md
+++ b/community.md
@@ -1,0 +1,19 @@
+---
+layout: default
+title: Hyperledger Contributors Community
+nav_order: 7
+---
+[//]: # (SPDX-License-Identifier: CC-BY-4.0)
+
+# Hyperledger Contributors Community
+
+**Note:** All are welcome at Hyperledger.
+The following list has all GitHub  contributors information.
+This is not an exhaustive list of all the contributions that
+Hyperledger receives.
+
+## Hyperledger GitHub Contributors
+
+## Hyperledger Labs GitHub Contributors
+
+## Hyperledger Tooling GitHub Contributors


### PR DESCRIPTION
This is not an exhaustive list of contributions that
Hyperledger receives. This information is polled only
from the GitHub. There are a lot many contributors doing
impact across Hyperledger.

Signed-off-by: S m, Aruna <arun.s.m.cse@gmail.com>